### PR TITLE
Ongoing Contests Information Fetch from Judges API

### DIFF
--- a/client/src/components/Contests/ContestDetails.js
+++ b/client/src/components/Contests/ContestDetails.js
@@ -45,6 +45,7 @@ class ContestDetails extends Component {
         problemsData: [],
         submissionsData: [],
         scoreData: [],
+        standingsData: [],
         isOwner: null,
         isParticipant: null,
         isValidated: null
@@ -64,52 +65,88 @@ class ContestDetails extends Component {
                     isParticipant: response.data.isParticipant
                 });
 
-                axios.post('http://127.0.0.1:5000/IsLoggedUserContestOwner', {
-                    contest_id: this.props.match.params.id
-                }, {withCredentials: true}).then(response => {
-                    if (response.data.status == 200){
-                        this.setState({ isOwner: true });
-                    }
-                    this.setState({ isValidated: true });
-                }).then( () => {
-                    if (this.props.isAdmin || this.state.isOwner) {
-                        axios.post('http://127.0.0.1:5000/GetSubmissionsInContest', {
+                if (response.data.contestInfo.status == 1) {
+                    axios.post('http://127.0.0.1:5000/IsLoggedUserContestOwner', {
+                        contest_id: this.props.match.params.id
+                    }, {withCredentials: true}).then(response => {
+                        if (response.data.status == 200) {
+                            this.setState({isOwner: true});
+                        }
+                    }).then(() => {
+                        axios.post('http://127.0.0.1:5000/GetContestProblems', {
                             contest_id: this.props.match.params.id
                         }).then(response => {
-                            if (response.data.status == 200){
-                                this.setState({ submissionsData: response.data.submissionsList });
+                            if (response.data.status == 200) {
+                                this.setState({problemsData: response.data.problemList});
+                                let problemIDList = [];
+                                this.state.problemsData.forEach(problem => {
+                                    problemIDList.push(problem.problemID.toString());
+                                });
                             }
                         });
-                    } else {
-                        axios.post('http://127.0.0.1:5000/GetUserSubmissionsInContest', {
-                            contest_id: this.props.match.params.id
-                        }, {withCredentials: true}).then(response => {
-                            if (response.data.status == 200){
-                                this.setState({ submissionsData: response.data.userSubmissionsList });
-                            }
-                        });
-                    }
-                });
 
-                axios.post('http://127.0.0.1:5000/GetContestProblems', {
-                    contest_id: this.props.match.params.id
-                }).then(response => {
-                    if (response.data.status == 200){
-                        this.setState({ problemsData: response.data.problemList });
-                        let problemIDList = [];
-                        this.state.problemsData.forEach(problem => {
-                            problemIDList.push(problem.problemID.toString());
+                        axios.post('http://127.0.0.1:5000/GetOngoingContestIntermediateData', {
+                            contest_id: this.props.match.params.id,
+                            can_see_all: this.props.isAdmin || this.state.isOwner
+                        }, {withCredentials: true}).then(response => {
+                           if (response.data.status == 200) {
+                               this.setState({
+                                   submissionsData: response.data.submissionsList,
+                                   scoreData: response.data.scoresList,
+                                   standingsData: response.data.standingsList
+                               });
+                               this.setState({isValidated: true});
+                           }
                         });
-                        if (problemIDList.length > 0) {
-                            axios.post('http://127.0.0.1:5000/GetContestScoresPerProblem', {
-                                contest_id: this.props.match.params.id,
-                                problem_id_list: problemIDList
+                    });
+                } else {
+                    axios.post('http://127.0.0.1:5000/IsLoggedUserContestOwner', {
+                        contest_id: this.props.match.params.id
+                    }, {withCredentials: true}).then(response => {
+                        if (response.data.status == 200) {
+                            this.setState({isOwner: true});
+                        }
+                        this.setState({isValidated: true});
+                    }).then(() => {
+                        if (this.props.isAdmin || this.state.isOwner) {
+                            axios.post('http://127.0.0.1:5000/GetSubmissionsInContest', {
+                                contest_id: this.props.match.params.id
                             }).then(response => {
-                                this.setState({scoreData: response.data.scoreList});
+                                if (response.data.status == 200) {
+                                    this.setState({submissionsData: response.data.submissionsList});
+                                }
+                            });
+                        } else {
+                            axios.post('http://127.0.0.1:5000/GetUserSubmissionsInContest', {
+                                contest_id: this.props.match.params.id
+                            }, {withCredentials: true}).then(response => {
+                                if (response.data.status == 200) {
+                                    this.setState({submissionsData: response.data.userSubmissionsList});
+                                }
                             });
                         }
-                    }
-                });
+                    });
+
+                    axios.post('http://127.0.0.1:5000/GetContestProblems', {
+                        contest_id: this.props.match.params.id
+                    }).then(response => {
+                        if (response.data.status == 200) {
+                            this.setState({problemsData: response.data.problemList});
+                            let problemIDList = [];
+                            this.state.problemsData.forEach(problem => {
+                                problemIDList.push(problem.problemID.toString());
+                            });
+                            if (problemIDList.length > 0) {
+                                axios.post('http://127.0.0.1:5000/GetContestScoresPerProblem', {
+                                    contest_id: this.props.match.params.id,
+                                    problem_id_list: problemIDList
+                                }).then(response => {
+                                    this.setState({scoreData: response.data.scoreList});
+                                });
+                            }
+                        }
+                    });
+                }
 
             } else {
                 this.setState({ isValidated: true })
@@ -152,7 +189,7 @@ class ContestDetails extends Component {
     render()
     {
         const { classes } = this.props;
-        const { isOwner, isParticipant, isValidated, contestName, description, status, problemsData, submissionsData, scoreData, tabValue } = this.state;
+        const { isOwner, isParticipant, isValidated, contestName, description, status, problemsData, standingsData, submissionsData, scoreData, tabValue } = this.state;
 
         if (isValidated)
             if (isOwner || isParticipant)
@@ -196,6 +233,8 @@ class ContestDetails extends Component {
                                     contest_id={this.props.match.params.id}
                                     problemList={problemsData}
                                     scores={scoreData}
+                                    standingsData = {standingsData}
+                                    status = {status}
                                 />
                             </TabContainer>}
                             {tabValue === 1 &&

--- a/client/src/components/Contests/StandingsTab.js
+++ b/client/src/components/Contests/StandingsTab.js
@@ -46,13 +46,17 @@ class StandingsTab extends Component {
     };
 
     componentDidMount(){
-        axios.post('http://127.0.0.1:5000/GetContestStandings', {
-            contest_id: this.props.contest_id
-        }).then(response => {
-            if (response.data.status == 200){
-                this.setState({ data: response.data.standingsList });
-            }
-        });
+        if (this.props.status == 1) {
+            this.setState({data: this.props.standingsData})
+        } else {
+            axios.post('http://127.0.0.1:5000/GetContestStandings', {
+                contest_id: this.props.contest_id
+            }).then(response => {
+                if (response.data.status == 200) {
+                    this.setState({data: response.data.standingsList});
+                }
+            });
+        }
     };
 
     handleRequestSort = (event, property, date) => {

--- a/client/src/components/Contests/StandingsTab.js
+++ b/client/src/components/Contests/StandingsTab.js
@@ -76,7 +76,7 @@ class StandingsTab extends Component {
 
     handleScoreDisplay = entryDict => {
         if (entryDict.result == '90')
-            return entryDict.submissionCount + '/' + (entryDict.TimeDifference + ((entryDict.submissionCount - 1) * 1200));
+            return entryDict.submissionCount + '/' + (entryDict.TimeDifference);
         return entryDict.submissionCount + '/--';
     }
 

--- a/flask-api/data/Procedures.sql
+++ b/flask-api/data/Procedures.sql
@@ -322,3 +322,30 @@ BEGIN
         status = p_new_status
     WHERE p_contestID = contestID;
 END //
+
+-- Get Ongoing Contest Info
+
+DELIMITER //
+
+CREATE PROCEDURE spGetOngoingContestInfo()
+BEGIN
+	SELECT contestID, startDate, endDate
+	FROM Contest
+	WHERE status = 1;
+END //
+
+-- Get Ongoing Contest Users Info
+
+DELIMITER //
+
+Drop Procedure If Exists spGetOngoingContestUsersInfo;
+
+CREATE PROCEDURE spGetOngoingContestUsersInfo (IN p_contestID INT)
+BEGIN
+	SELECT CU.userID, U.username, U.iduva, U.idicpc, C.country_name
+	FROM ContestUser CU, Users U
+	LEFT OUTER JOIN Countries C ON U.country = C.id
+	WHERE CU.contestID = p_contestID AND CU.userID = U.userID
+	ORDER BY CU.userID;
+
+END //

--- a/flask-api/data/Procedures.sql
+++ b/flask-api/data/Procedures.sql
@@ -369,16 +369,53 @@ BEGIN
 
 END //
 
+-- Get Almost Finished Contest Info
+
+DELIMITER //
+
+CREATE PROCEDURE spGetAlmostFinishedContestInfo()
+BEGIN
+	SELECT contestID, startDate, endDate, CURRENT_TIMESTAMP AS currentDate
+	FROM Contest
+	WHERE status = 1 AND endDate <= CURRENT_TIMESTAMP;
+END //
+
 -- Contest Update Ongoing to Finished
 
 DELIMITER //
 
-Drop Procedure If Exists sspUpdateContestOngoingToFinished;
+Drop Procedure If Exists spUpdateContestOngoingToFinished;
 
-CREATE PROCEDURE spUpdateContestOngoingToFinished()
+CREATE PROCEDURE spUpdateContestOngoingToFinished(IN p_updateDate DATETIME)
 BEGIN
 	UPDATE Contest
 	SET status = 2
-	WHERE status = 1 AND endDate <= CURRENT_TIMESTAMP;
+	WHERE status = 1 AND endDate <= p_updateDate;
+
+END //
+
+-- Insert Finished Contest Submission
+
+DELIMITER //
+
+DROP PROCEDURE IF EXISTS spInsertSubmission;
+
+CREATE PROCEDURE spInsertSubmission(IN p_subDate DATETIME, IN p_result INT, IN p_language VARCHAR(64), IN p_problemID INT, IN p_submitter INT, IN p_contestID INT)
+BEGIN
+  INSERT INTO Submission VALUES
+	(NULL, p_subDate, p_result, p_language, 0, p_problemID, p_submitter, p_contestID);
+END //
+
+-- Update Contest User Info
+
+DELIMITER //
+
+DROP PROCEDURE IF EXISTS spUpdateContestUser;
+
+CREATE PROCEDURE spUpdateContestUser(IN p_score INT, IN p_standing INT, IN p_contestID INT, IN p_userID INT)
+BEGIN
+  UPDATE ContestUser
+  SET score = p_score, standing = p_standing
+  WHERE contestID = p_contestID AND userID = p_userID;
 
 END //


### PR DESCRIPTION
**IMPORTANT: UPDATE STORED PROCEDURES BEFORE TESTING**

Before running the Flask API, run the following command in your terminal:
`$ pip install apscheduler`

Implemented a back-end method to fetch ongoing contests' information from the judges APIs and save it in an intermediate global structure, as well as handle any contest state changes. This method is attached to a BackgroundScheduler object, which executes it every 5 minutes (interval can be changed). Created API end-point to fetch an ongoing contests' data from the global structure. Finally, linked the React app to these methods.

Enjoy! Happy testing!